### PR TITLE
Modified utils/pseudo-term.lisp and refactoring other files

### DIFF
--- a/books/projects/smtlink/trusted/z3-py/translate-declarations.lisp
+++ b/books/projects/smtlink/trusted/z3-py/translate-declarations.lisp
@@ -17,6 +17,7 @@
 (include-book "translate-quote")
 
 (local (in-theory (enable paragraph-p word-p pseudo-term-fix)))
+(set-induction-depth-limit 1)
 
 (define conjunction-to-list ((decl-term pseudo-termp)
                              (acc pseudo-term-listp))
@@ -83,6 +84,7 @@
 
 (define translate-declaration-list ((decl-list pseudo-term-listp))
   :returns (translated paragraph-p)
+  :measure (len decl-list)
   (b* ((decl-list (pseudo-term-list-fix decl-list))
        ((unless (consp decl-list)) nil)
        ((cons decl-hd decl-tl) decl-list))

--- a/books/projects/smtlink/verified/expand-cp.lisp
+++ b/books/projects/smtlink/verified/expand-cp.lisp
@@ -1029,7 +1029,7 @@
 			                         acl2::subsetp-when-atom-left
 			                         symbol-listp-of-car-when-symbol-list-listp
 			                         member-equal
-			                         null-of-pseudo-term-list-fix
+			                         ;null-of-pseudo-term-list-fix
 			                         pseudo-termp-of-car-when-member-equal-of-pseudo-term-sym-alistp
 			                         acl2::consp-of-symbol-list-fix
 			                         symbol-list-listp-of-cdr-when-symbol-list-listp

--- a/books/projects/smtlink/verified/judgement-fns.lisp
+++ b/books/projects/smtlink/verified/judgement-fns.lisp
@@ -20,6 +20,8 @@
 
 (set-state-ok t)
 
+(set-induction-depth-limit 1)
+
 (local
  (defthm symbol-is-pseudo-term
    (implies (symbolp x) (pseudo-termp x))))
@@ -167,6 +169,7 @@
   :returns (new-args pseudo-term-listp
                      :hints (("Goal" :in-theory (enable pseudo-termp
                                                         pseudo-term-listp))))
+  :measure (len args)
   (b* ((args (pseudo-term-list-fix args))
        (new-var (pseudo-term-fix new-var))
        ((unless (consp args)) nil)
@@ -635,6 +638,7 @@
                              (then-args pseudo-term-listp)
                              (else-args pseudo-term-listp))
   :returns (new-args pseudo-term-listp)
+  :measure (len then-args)
   (b* ((if-cond (pseudo-term-fix if-cond))
        (then-args (pseudo-term-list-fix then-args))
        (else-args (pseudo-term-list-fix else-args))

--- a/books/projects/smtlink/verified/judgements.lisp
+++ b/books/projects/smtlink/verified/judgements.lisp
@@ -19,6 +19,7 @@
 (define only-one-var-acc ((term-lst pseudo-term-listp)
                           (term pseudo-termp)
                           (count natp))
+  :measure (len term-lst)
   :returns (ok booleanp)
   (b* ((term-lst (pseudo-term-list-fix term-lst))
        (count (nfix count))

--- a/books/projects/smtlink/verified/returns-judgement.lisp
+++ b/books/projects/smtlink/verified/returns-judgement.lisp
@@ -22,6 +22,7 @@
 
 (set-state-ok t)
 
+(set-induction-depth-limit 1)
 (local (in-theory (disable pseudo-termp pseudo-term-listp)))
 
 ;;-------------------------------------------------------
@@ -344,6 +345,7 @@
                               (actuals pseudo-term-listp)
                               (supertypes type-to-types-alist-p))
   :returns (judge-alst pseudo-term-alistp)
+  :measure (len actuals)
   (b* ((actuals (pseudo-term-list-fix actuals))
        ((unless (consp actuals)) nil)
        ((cons ac-hd ac-tl) actuals))


### PR DESCRIPTION
Modified utils/pseudo-term.lisp to use fty:deflist for pseudo-term-list and pseudo-term-list-list.

Updated other files to get a successful build and run of examples/examples.lisp.
Most of the changes were adding :measure declarations for functions.
For many of the modified files, I added (set-induction-depth-limit 1).
This required adding one more lemma for the proof of
  number-of-unresolved-decreases-term-var-alst-2
in reorder-hypotheses.lisp.  I noted that theorems lemma-1, lemma-2,
and lemma-3 were *not* declared local.  I'm pretty sure you don't want to
block anyone else from using these names (locally); so, I wrapped them with
  (local ...)

I'm guessing that I could add an (in-theory (disable ...)) form at the end
of utils/pseudo-term.lisp that would make many book certifications run *much*
faster, but would require a few :in-theory (enable ...) hints.  I'm going to
do this push now, and leave this faster-certification modification for later.